### PR TITLE
fix: 修正 nginx upstream server 的参数被丢弃的问题

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -85,7 +85,7 @@ function config_https() {
     HTTPS_PORT=443
   fi
 
-  sed -i "s@server web:.*;@server localhost:51980;@g" "${config_file}"
+  sed -i "s@server web[:0-9]*@server localhost:51980@g" "${config_file}"
 
   if [ "${USE_IPV6}" == "1" ]; then
     sed -i "s@# listen \[::\]:443@listen \[::\]:443@g" "${config_file}"


### PR DESCRIPTION
当 server web:8080 后面添了加其它参数时，会在替换时被丢弃。

v3.10.12 版演示如下：
```
root@jms_web:/opt# head /etc/nginx/sites-enabled/https_server.conf
# Todo: May be can auto discovery
upstream http_server {
  ip_hash;
  server web:8080 weight=10;  # 这个是可以通过容器访问, 外部访问是 80端口
  # server HOST2:80;  # 另外的要写真实IP
  server 10.189.143.92:8980 weight=6;
}
...

root@jms_web:/opt# diff /etc/nginx/sites-enabled/https_server.conf /etc/nginx/conf.d/https_server.conf
4c4
<   server web:8080 weight=10;  # 这个是可以通过容器访问, 外部访问是 80端口
---
>   server localhost:51980;  # 这个是可以通过容器访问, 外部访问是 80端口
```
'weight=10' 被丢弃了。


修正后，不同情况的测试结果如下：
```
$ echo 'server web:8080 weight=10;  # 这个是可以通过容器访问, 外部访问是 80端口' | sed "s@server web[:0-9]*@server localhost:51980@g"
server localhost:51980 weight=10;  # 这个是可以通过容器访问, 外部访问是 80端口

$ echo 'server web:8080;  # 这个是可以通过容器访问, 外部访问是 80端口' | sed "s@server web[:0-9]*@server localhost:51980@g"
server localhost:51980;  # 这个是可以通过容器访问, 外部访问是 80端口

$ echo 'server web;  # 这个是可以通过容器访问, 外部访问是 80端口' | sed "s@server web[:0-9]*@server localhost:51980@g"
server localhost:51980;  # 这个是可以通过容器访问, 外部访问是 80端口
```