### PR TITLE
perf: 配置 nginx 对 css, js, xml 等静态文件打开 gzip 压缩，提高下载速度

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -39,6 +39,9 @@ http {
     keepalive_timeout  65;
 
     gzip  on;
+    gzip_min_length  1k;
+    gzip_types  text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip_vary  on;
     server_tokens off;
 
     include /etc/nginx/conf.d/*.conf;


### PR DESCRIPTION
有些静态资源文件比如 js 体积较大，在网络质量较差的情况下载耗时较长，通过开启 gzip 压缩，提高下载速度。 @ibuler 